### PR TITLE
Fix deprecate template-lint rule name

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     recommended: {
       extends: 'recommended',
       rules: {
-        'img-alt-attributes': false,
+        'require-valid-alt-text': false,
         'simple-unless': false,
         quotes: 'double',
       },


### PR DESCRIPTION
Renames `img-alt-attributes` -> `require-valid-alt-text`